### PR TITLE
fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # hxexpress
 
 ```
-haxelib install git https://github.com/abedev/hxexpress
+haxelib git express https://github.com/abedev/hxexpress
 ```


### PR DESCRIPTION
as title, assuming the name should be 'express' not 'hxexpress' as the error I got said to 'haxelib install express' so I assume thats how you import it in your code
