### PR TITLE
Added Express.json() for express 4.16.0+

### DIFF
--- a/src/express/Express.hx
+++ b/src/express/Express.hx
@@ -2,6 +2,7 @@ package express;
 
 import express.Middleware;
 import haxe.extern.Rest;
+import mw.bodyparser.JsonOptions;
 
 @:jsRequire("express")
 extern class Express extends Route {
@@ -34,6 +35,7 @@ extern class Express extends Route {
   @:overload(function(path : String, router : Router) : Express {})
   function use(path : String, callback : EitherMiddleware, callbacks : Rest<Middleware>) : Express;
 
+  static function json(?options : JsonOptions) : Middleware;
   inline static function serveStatic(root : String, ?options : StaticOptions) : Middleware
     return untyped Express["static"](root, options);
 }


### PR DESCRIPTION
Express.json() is a proxy to body-parser, now included in express: https://expressjs.com/en/4x/api.html#express.json