### PR TITLE
Fix deprecated class paths (haxe 4)

### DIFF
--- a/src/express/Error.hx
+++ b/src/express/Error.hx
@@ -1,6 +1,6 @@
 package express;
 
 @:native("Error")
-extern class Error extends js.Error {
+extern class Error extends #if (haxe_ver>=4.0) js.lib.Error #else js.Error #end {
   public var status : Int;
 }

--- a/src/express/Next.hx
+++ b/src/express/Next.hx
@@ -12,7 +12,7 @@ abstract Next(Dynamic)
   public inline function call()
     untyped this();
 
-  public inline function error(err : js.Error)
+  public inline function error(err : #if (haxe_ver >= 4.0) js.lib.Error #else js.Error #end)
     untyped this(err);
 
   public inline function route()

--- a/src/mw/BasicAuth.hx
+++ b/src/mw/BasicAuth.hx
@@ -5,7 +5,11 @@ import haxe.crypto.Base64;
 import express.Request;
 import express.Response;
 import express.Next;
+#if (haxe_ver >= 4.0)
+import js.lib.Error;
+#else
 import js.Error;
+#end
 import js.node.Buffer;
 using StringTools;
 

--- a/src/mw/BearerTokenAuth.hx
+++ b/src/mw/BearerTokenAuth.hx
@@ -3,7 +3,11 @@ package mw;
 import express.Request;
 import express.Response;
 import express.Next;
+#if (haxe_ver >= 4.0)
+import js.lib.Error;
+#else
 import js.Error;
+#end
 using StringTools;
 
 class BearerTokenAuth {

--- a/src/mw/OnFinished.hx
+++ b/src/mw/OnFinished.hx
@@ -2,7 +2,12 @@ package mw;
 
 import express.Request;
 import express.Response;
+
+#if (haxe_ver >= 4.0)
+import js.lib.Error;
+#else
 import js.Error;
+#end
 
 @:jsRequire("on-finished")
 extern class OnFinished {

--- a/src/mw/Unless.hx
+++ b/src/mw/Unless.hx
@@ -3,7 +3,11 @@ package mw;
 import express.Request;
 import express.Middleware;
 import haxe.extern.EitherType;
+#if (haxe_ver >= 4.0)
+import js.lib.RegExp;
+#else
 import js.RegExp;
+#end
 import mw.jwt.*;
 
 @:jsRequire("express-unless")

--- a/src/mw/cors/Options.hx
+++ b/src/mw/cors/Options.hx
@@ -2,7 +2,11 @@ package mw.cors;
 
 import express.Request;
 import haxe.extern.EitherType;
+#if (haxe_ver >= 4.0)
+import js.lib.Error;
+#else
 import js.Error;
+#end
 
 typedef Options = {
   ?origin : EitherType<Bool, EitherType<String, OriginFunction>>,

--- a/src/mw/expressbrute/Options.hx
+++ b/src/mw/expressbrute/Options.hx
@@ -39,8 +39,15 @@ Defines whether the remaining lifetime of a counter should be based on the time 
 /*
 Gets called whenever an error occurs with the persistent store from which ExpressBrute cannot recover. It is passed an object containing the properties message (a description of the message), parent (the error raised by the session store), and [key, ip] or [req, res, next] depending on whether or the error occurs during reset or in the middleware itself.
 */
+#if (haxe_ver >= 4.0)
+  ?handleStoreError : EitherType<
+    ({ message : String, parent : js.lib.Error}, String, String) -> Void,
+    ({ message : String, parent : js.lib.Error}, Request, Response, Next) -> Void
+  >
+#else
   ?handleStoreError : EitherType<
     { message : String, parent : js.Error} -> String -> String -> Void,
     { message : String, parent : js.Error} -> Request -> Response -> Next -> Void
   >
+#end
 }


### PR DESCRIPTION
For haxe 4:
js.Error -> js.lib.Error
js.RegExp -> js.lib.RegExp

Uses conditional compilation so should still work with older versions
of haxe

Closes #32 